### PR TITLE
Fix a random condition which was causing firePhoneGapAvailable called twice

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/PhoneGapStandardImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/PhoneGapStandardImpl.java
@@ -104,7 +104,8 @@ public class PhoneGapStandardImpl implements PhoneGap {
 				@Override
 				public void run() {
 					if (isPhoneGapInitialized()) {
-						return;
+					  firePhoneGapAvailable();
+					  return;
 					}
 
 					if (System.currentTimeMillis() - end > 0) {
@@ -318,7 +319,6 @@ public class PhoneGapStandardImpl implements PhoneGap {
 
 	protected void nativeDeviceReady() {
 		deviceReady = true;
-		firePhoneGapAvailable();
 	}
 
 	private native void setupReadyHook() /*-{


### PR DESCRIPTION
When nativeDeviceReady is called, it should just set to true the deviceReady flag but not fire the phonegap-available-event because the user could not have set the availableHandler or she could not have called the initialize.

initializePhonegap is the responsible to fire that event whenever it realizes the device is ready.

Issues fixed:
- Sometimes the available event was being called twice: one from the nativeDeviceReady method, and another from the initializePhoneGap (line 99)
- Sometimes the firePhoneGapAvailable was called before the initializePhonegap call
- Under certain circumstances PhoneGapAvailableHandler could be never called (i have not seen this condition but I think it was possible).
