### PR TITLE
Fixing file mime type and file copy in RemoteFileServlet

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/server/file/FileRemoteServiceServlet.java
+++ b/src/main/java/com/googlecode/gwtphonegap/server/file/FileRemoteServiceServlet.java
@@ -448,7 +448,7 @@ public class FileRemoteServiceServlet extends RemoteServiceServlet implements Fi
 		File oldFile = new File(basePath, filePath);
 		ensureLocalRoot(basePath, oldFile);
 
-		File newFile = new File(basePath, newName);
+		File newFile = new File(directory, newName);
 		ensureLocalRoot(basePath, newFile);
 
 		try {


### PR DESCRIPTION
The RemoteFileServet.getFileObject() method didn't put the mime type in file 'type' property.
File not copied to target directory in remote filesystem in the fileCopy() method.
