### PR TITLE
missing method openExternal

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowser.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowser.java
@@ -20,10 +20,36 @@ import com.googlecode.gwtphonegap.client.plugins.PhoneGapPlugin;
 
 public interface ChildBrowser extends PhoneGapPlugin {
 
+  /**
+   * Display a new browser with the specified URL.
+   * This method loads up a new web view in a dialog which
+   * shows a location bar.
+   *
+   * @param url
+   */
   public void showWebPage(String url);
   
+  /**
+   * Display a new browser with the specified URL.
+   * This method loads up a new web view in a dialog.
+   *
+   * @param url
+   * @param showLocationBar show the location bar
+   */
   public void showWebPage(String url, boolean showLocationBar);
 
+  /**
+   * Display a new browser with the specified URL.
+   * This method starts a new web browser activity.
+   *
+   * @param url
+   * @param usecordova whether load url in cordova webview
+   */
+  public void openExternal(String url, boolean usecordova);
+
+  /**
+   * Close the browser opened by showWebPage.
+   */
 	public void close();
 
 	public HandlerRegistration addLocationChangeHandler(ChildBrowserLocationChangedHandler handler);

--- a/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowserBrowserImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowserBrowserImpl.java
@@ -26,6 +26,7 @@ import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
 import com.google.web.bindery.event.shared.SimpleEventBus;
 import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
@@ -199,5 +200,10 @@ public class ChildBrowserBrowserImpl implements ChildBrowser {
 	private void onLocationChange(String url) {
 		handlerManager.fireEvent(new ChildBrowserLocationChangedEvent(url));
 	}
+
+  @Override
+  public void openExternal(String url, boolean usecordova) {
+    Window.open(url, "_blank", "");
+  }
 
 }

--- a/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowserPhoneGapImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/plugins/childbrowser/ChildBrowserPhoneGapImpl.java
@@ -34,7 +34,7 @@ public class ChildBrowserPhoneGapImpl implements ChildBrowser {
 			cb = initializeNative();
 			initialized = true;
 		} catch (JavaScriptException e) {
-			throw new IllegalStateException("could not initialize Childbrowser plugin");
+			throw new IllegalStateException("could not initialize Childbrowser plugin: " + e.getMessage());
 		}
 
 	}
@@ -96,6 +96,19 @@ public class ChildBrowserPhoneGapImpl implements ChildBrowser {
 	private native void showWebPageNative(JavaScriptObject cb, String url, boolean showLocationBar)/*-{
 		cb.showWebPage(url, {showLocationBar: showLocationBar});
 	}-*/;
+
+  @Override
+  public void openExternal(String url, boolean usecordova) {
+    if (!initialized) {
+      throw new IllegalStateException("you have to initialize Childbrowser before using it");
+    }
+
+    openExternalNative(cb, url, usecordova);
+  }
+
+  private native void openExternalNative(JavaScriptObject cb, String url, boolean usecordova)/*-{
+    cb.openExternal(url, usecordova);
+  }-*/;
 
 	@Override
 	public void close() {


### PR DESCRIPTION
This commit adds the openExternal method in ChildBrowser and a couple of javadoc descriptions taken from the phonegap documentation.
