### PR TITLE
added abort() to the FileTransfer (introduced in cordova 2.2)

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/file/FileTransfer.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/file/FileTransfer.java
@@ -19,4 +19,6 @@ public interface FileTransfer {
 	public void upload(String fileUri, String serverUrl, FileUploadOptions options, FileUploadCallback callback);
 
 	public void download(String sourceUrl, String filePath, FileDownloadCallback callback);
+
+	public void abort();
 }

--- a/src/main/java/com/googlecode/gwtphonegap/client/file/browser/FileBrowserImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/file/browser/FileBrowserImpl.java
@@ -40,7 +40,7 @@ import com.googlecode.gwtphonegap.collection.shared.LightArray;
  */
 public class FileBrowserImpl implements File {
 
-	private FileSystemController fileController;
+	private final FileSystemController fileController;
 
 	public FileBrowserImpl() {
 		fileController = new FileSystemController();
@@ -94,6 +94,11 @@ public class FileBrowserImpl implements File {
 				};
 
 				callback.onFailure(fileTransferError);
+
+			}
+
+			@Override
+			public void abort() {
 
 			}
 		};

--- a/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileTransferJsImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileTransferJsImpl.java
@@ -33,6 +33,11 @@ public final class FileTransferJsImpl extends JavaScriptObject implements FileTr
 	}
 
 	@Override
+	public native void abort()/*-{
+		this.abort();
+	}-*/;
+
+	@Override
 	public void download(String sourceUrl, String filePath, FileDownloadCallback callback) {
 		download0(sourceUrl, filePath, callback);
 	}


### PR DESCRIPTION
added abort() to the FileTransfer (introduced in cordova 2.2)
