### PR TITLE
Issue 66: Blackberry Phonegap environment not detected

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/PhoneGap.gwt.xml
+++ b/src/main/java/com/googlecode/gwtphonegap/PhoneGap.gwt.xml
@@ -10,7 +10,7 @@
 	    if (ua.indexOf('android') != -1 || ua.indexOf('ipad') != -1 || ua.indexOf('ipod') != -1  || ua.indexOf('iphone') != -1 || ua.indexOf('blackberry') != -1) 
 	    { 
 	    	var url = document.location.href;
-	    	if(url.indexOf("file://") === 0)
+	    	if(url.indexOf("file://") === 0 || url.indexOf("local://") === 0)
 	    	{
 	    		return "yes";
 	    	}


### PR DESCRIPTION
Fixed Issue 66: Blackberry Phonegap environment not detected
https://code.google.com/p/gwt-phonegap/issues/detail?id=66
