### PR TITLE
BugFix for typo within parameter name

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/inappbrowser/InAppBrowserReference.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/inappbrowser/InAppBrowserReference.java
@@ -32,5 +32,5 @@ public interface InAppBrowserReference {
 
   void injectCss(String css, InAppBrowserCallback  callback);
 
-  void injectCssFromUrl(String u  rl, InAppBrowserCallback  callback);
+  void injectCssFromUrl(String url, InAppBrowserCallback  callback);
 }


### PR DESCRIPTION
I think there was a typo in this interface
