### PR TITLE
Compatible to Apache Cordova 3.3

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/Accelerometer.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/Accelerometer.java
@@ -36,9 +36,8 @@ public interface Accelerometer {
 	 * </ul>
 	 * 
 	 * @param accelerationCallback
-	 * @param options
 	 */
-	public void getCurrentAcceleration(AccelerationCallback accelerationCallback, AccelerationOptions options);
+	public void getCurrentAcceleration(AccelerationCallback accelerationCallback);
 
 	/**
 	 * At a regular interval, get the acceleration along the x, y, and z axis.

--- a/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/browser/AccelerometerBrowserImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/browser/AccelerometerBrowserImpl.java
@@ -29,7 +29,7 @@ import com.googlecode.gwtphonegap.client.accelerometer.AccelerometerWatcher;
 public class AccelerometerBrowserImpl implements Accelerometer, AccelermeterMock {
 
 	@Override
-	public void getCurrentAcceleration(AccelerationCallback accelerationCallback, AccelerationOptions options) {
+	public void getCurrentAcceleration(AccelerationCallback accelerationCallback) {
 		accelerationCallback.onSuccess(new AccelerationBrowserImpl(0, 0, 0));
 	}
 

--- a/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/js/AccelerometerMobileImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/accelerometer/js/AccelerometerMobileImpl.java
@@ -29,10 +29,10 @@ import com.googlecode.gwtphonegap.client.accelerometer.AccelerometerWatcher;
 public class AccelerometerMobileImpl implements Accelerometer {
 
 	/* (non-Javadoc)
-	 * @see com.googlecode.gwtphonegap.client.accelerometer.Accelerometer#getCurrentAcceleration(com.googlecode.gwtphonegap.client.accelerometer.AccelerationCallback, com.googlecode.gwtphonegap.client.accelerometer.AccelerationOptions)
+	 * @see com.googlecode.gwtphonegap.client.accelerometer.Accelerometer#getCurrentAcceleration(com.googlecode.gwtphonegap.client.accelerometer.AccelerationCallback)
 	 */
 	@Override
-	public native void getCurrentAcceleration(AccelerationCallback accelerationCallback, AccelerationOptions options) /*-{
+	public native void getCurrentAcceleration(AccelerationCallback accelerationCallback) /*-{
 		var successCallback = function(data) {
 			accelerationCallback.@com.googlecode.gwtphonegap.client.accelerometer.AccelerationCallback::onSuccess(Lcom/googlecode/gwtphonegap/client/accelerometer/Acceleration;)(data);
 		};
@@ -41,14 +41,8 @@ public class AccelerometerMobileImpl implements Accelerometer {
 			accelerationCallback.@com.googlecode.gwtphonegap.client.accelerometer.AccelerationCallback::onFailure()();
 		};
 
-		var freq = options.@com.googlecode.gwtphonegap.client.accelerometer.AccelerationOptions::getFrequency()();
-
-		var localOptions = {
-			frequency : freq
-		}
-
 		$wnd.navigator.accelerometer.getCurrentAcceleration(
-				$entry(successCallback), $entry(errorCallback), localOptions);
+				$entry(successCallback), $entry(errorCallback));
 	}-*/;
 
 	@Override


### PR DESCRIPTION
Removed options parameter from getCurrentAcceleration method.
