### PR TITLE
Dev mode file write

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/server/file/FileRemoteServiceServlet.java
+++ b/src/main/java/com/googlecode/gwtphonegap/server/file/FileRemoteServiceServlet.java
@@ -272,16 +272,15 @@ public class FileRemoteServiceServlet extends RemoteServiceServlet implements Fi
 
 		try {
 
-			StringBuffer buffer;
+			StringBuffer buffer = new StringBuffer();
 
 			int position;
 
 			if (fileWriterDTO.getPosition() == 0) {
-				buffer = new StringBuffer(content);
+				buffer.append(content);
 				position = content.length();
 			} else {
 				String fileInString = FileUtils.readFileToString(file);
-				buffer = new StringBuffer(fileInString);
 				int end = (int) fileWriterDTO.getPosition();
 				if (end > fileInString.length()) {
 					end = fileInString.length();


### PR DESCRIPTION
The fileWriterDTO.getPosition() == 0 case is definitely wrong, because it appends new content to the old content. On an iPad the content is also replaced.
The else case also seems to be wrong, but I never tried to write to different file positions.
