### PR TITLE
Remove gwt.logging.popupHandler for GWT 2.7

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/PhoneGap.gwt.xml
+++ b/src/main/java/com/googlecode/gwtphonegap/PhoneGap.gwt.xml
@@ -325,7 +325,6 @@
 	
 	<!-- disable default gwt Log handler -->
 	<set-property name="gwt.logging.consoleHandler" value="DISABLED"/> 
-	<set-property name="gwt.logging.popupHandler" value="DISABLED" />
 	
 	
 	


### PR DESCRIPTION
Remove gwt.logging.popupHandler for GWT 2.7
