### PR TITLE
Fixed request headers property name

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileTransferJsImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileTransferJsImpl.java
@@ -88,7 +88,7 @@ public final class FileTransferJsImpl extends JavaScriptObject implements FileTr
 		fop.fileName = options.@com.googlecode.gwtphonegap.client.file.FileUploadOptions::getFileName()();
 		fop.mimeType = options.@com.googlecode.gwtphonegap.client.file.FileUploadOptions::getMimeType()();
 		fop.params = map;
-		fop.heaaders = headers;
+		fop.headers = headers;
 
 		this.upload(fileUri, serverUrl, $entry(suc), $entry(fail), fop);
   }-*/;


### PR DESCRIPTION
Thanks for all of your work on this project. I believe there is a small typo in the transfer javascript which meant that upload headers did not come through, which affects versions at least up to 3.5.0.1.