### PR TITLE
Fix bug in File moveTo and copyTo implementation

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileEntryJsImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/file/js/FileEntryJsImpl.java
@@ -88,7 +88,7 @@ public class FileEntryJsImpl implements FileEntry {
 			that.@com.googlecode.gwtphonegap.client.file.js.FileEntryJsImpl::onMoveToSuccess(Lcom/googlecode/gwtphonegap/client/file/FileCallback;Lcom/google/gwt/core/client/JavaScriptObject;)(callback, entry);
 		};
 
-		var entry = (this.@com.googlecode.gwtphonegap.client.file.js.DirectoryEntryJsImpl::entry);
+		var entry = (this.@com.googlecode.gwtphonegap.client.file.js.FileEntryJsImpl::entry);
 
 		entry.moveTo(parent, newName, $entry(suc), $entry(fail));
 
@@ -118,7 +118,7 @@ public class FileEntryJsImpl implements FileEntry {
 			that.@com.googlecode.gwtphonegap.client.file.js.FileEntryJsImpl::onCopyToSuccess(Lcom/googlecode/gwtphonegap/client/file/FileCallback;Lcom/google/gwt/core/client/JavaScriptObject;)(callback, entry);
 		};
 
-		var entry = (this.@com.googlecode.gwtphonegap.client.file.js.DirectoryEntryJsImpl::entry);
+		var entry = (this.@com.googlecode.gwtphonegap.client.file.js.FileEntryJsImpl::entry);
 
 		entry.copyTo(parent, newName, $entry(suc), $entry(fail));
 


### PR DESCRIPTION
Both functions did not work because they were referring to
DirectoryEntryJsImpl::entry instead of FileEntryJsImpl::entry