### PR TITLE
changes to vibrate API for cordova 5.1 support.

### DIFF
--- a/src/main/java/com/googlecode/gwtphonegap/client/notification/Notification.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/notification/Notification.java
@@ -40,26 +40,20 @@ public interface Notification {
 
 	public void beep(int count);
 
+        /**
+         * Vibrates the device for provided number of milliseconds.
+         * To cancel the vibration, pass 0 as parameter.
+         * @param milliseconds 
+         */ 
 	public void vibrate(int milliseconds);
         
         /**
-        * Vibrates the device with a given pattern. The pattern is not repeated.
+        * Vibrates the device with a given pattern.
         *
         * @param pattern :Sequence of durations (in milliseconds) for which to turn
         * on or off the vibrator. (Array of Numbers)
         */
         public void vibrateWithPattern(int[] pattern);
-
-       /**
-        * Vibrates the device with a given pattern.
-        *
-        * @param pattern:Sequence of durations (in milliseconds) for which to turn
-        * on or off the vibrator. (Array of Numbers)
-        * @param repeat :Optional index into the pattern array at which to start
-        * repeating (will repeat until canceled), or -1 for no repetition
-        * (default). (Number)
-        */
-        public void vibrateWithPattern(int[] pattern, int repeat);
 
        /**
         * Immediately cancels any currently running vibration.

--- a/src/main/java/com/googlecode/gwtphonegap/client/notification/NotificationBrowserImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/notification/NotificationBrowserImpl.java
@@ -40,11 +40,6 @@ public class NotificationBrowserImpl implements Notification {
         }
 
         @Override
-        public void vibrateWithPattern(int[] pattern, int repeat) {
-           
-        }
-
-        @Override
         public void cancelVibrate() {
             
         }

--- a/src/main/java/com/googlecode/gwtphonegap/client/notification/NotificationMobileImpl.java
+++ b/src/main/java/com/googlecode/gwtphonegap/client/notification/NotificationMobileImpl.java
@@ -61,18 +61,6 @@ public class NotificationMobileImpl implements Notification {
         }-*/;
 
         @Override
-        @Deprecated
-        public void vibrateWithPattern(int[] pattern, int repeat){
-            JsArrayInteger jsPattern =  JsArrayUtils.readOnlyJsArray(pattern);
-            vibrateWithPattern0(jsPattern, repeat);
-        }
-        
-        @Deprecated
-        public native void vibrateWithPattern0(JsArrayInteger pattern, int repeat)/*-{
-		$wnd.navigator.notification.vibrateWithPattern(pattern,repeat);
-	}-*/;
-
-        @Override
         public native void cancelVibrate() /*-{
 		$wnd.navigator.vibrate(0);
 	}-*/;


### PR DESCRIPTION
Removed vibrateWithPattern(int[] pattern, int repeat) which is not supported in the latest version of cordova.
